### PR TITLE
Allow preflight to fail in preview

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -16,7 +16,7 @@ dependencies:
 
 test:
   post:
-    - if [[ $PREVIEW == "true" ]]; then npm run preflight || echo "WARNING: preflight failed!"; else npm run preflight; fi
+    - if [[ $PREVIEW == "true" ]]; then npm run preflight || echo WARNING - preflight failed; else npm run preflight; fi
 
 deployment:
   s3: # this is just a custom name, could be anything


### PR DESCRIPTION
With this change, if the preflight test fails and PREVIEW is on, it will just print a warning and then proceed with the preview deployment, so you can hopefully see what's wrong by looking at the deployed page.

@joannaskao 